### PR TITLE
Fix broken help section link

### DIFF
--- a/week-1.md
+++ b/week-1.md
@@ -167,7 +167,7 @@ Let us know what you thought of the homework, what part you spend a lot of time 
 
 
 
-[bugs]: readme.md#communication
+[bugs]: https://github.com/cmda-bt/be-course-18-19#communication
 
 [quote-author]: https://twitter.com/BrendanEich
 

--- a/week-2.md
+++ b/week-2.md
@@ -140,7 +140,7 @@ Let us know what you thought of the homework, what part you spend a lot of time 
 
 
 
-[bugs]: readme.md#communication
+[bugs]: https://github.com/cmda-bt/be-course-18-19#communication
 
 [inspiration-cover]: https://http.cat/403
 

--- a/week-3.md
+++ b/week-3.md
@@ -92,7 +92,7 @@ Work on receiving user input and manipulating data for your own Job Story.
 
 #### Tips
 
-*   Stuck?  See the [Bugs](https://github.com/cmda-bt/be-course-18-19#communication) section of the course readme to find a list of
+*   Stuck?  See the [Bugs][] section of the course readme to find a list of
     troubleshooting tips
 
 #### Description

--- a/week-3.md
+++ b/week-3.md
@@ -128,7 +128,7 @@ Mark this assignment as complete by opening an issue on our [GitHub issue tracke
 Let us know what you thought of the homework, what part you spend a lot of time on and give us any feedback. Your project will be reviewed and receive feedback, so expect people to read it, and be ready for tips and tops!
 
 
-[bugs]: readme.md#communication
+[bugs]: https://github.com/cmda-bt/be-course-18-19#communication
 
 [inspiration-cover]: assets/images/dog-ceo.png
 

--- a/week-4.md
+++ b/week-4.md
@@ -70,7 +70,7 @@ In this assignment you’ll store the user input in a `MongoDB` database.
 
 *   [`mongodb-server`](examples/mongodb-server)
     (**example**)
-*   Stuck?  See the [Bugs](/readme#communication) section of the course readme to find a list of
+*   Stuck?  See the [Bugs](https://github.com/cmda-bt/be-course-18-19#communication) section of the course readme to find a list of
     troubleshooting tips
 
 #### Description
@@ -157,7 +157,7 @@ Let us know what you thought of the homework, what part you spend a lot of time 
 
 [slides-lab]: https://docs.google.com/presentation/d/1FqZ08Yf5IL6kCUjKO53VrWoipsn4foXQAFerjrmHRp8/edit?usp=sharing
 
-[bugs]: readme.md#bugs
+[bugs]: https://github.com/cmda-bt/be-course-18-19#communication
 
 [quote-author]: https://twitter.com/shatterfront/status/816065700577972224
 

--- a/week-5.md
+++ b/week-5.md
@@ -51,7 +51,7 @@ Presenting your work is a skill all by itself, make sure you prepare yourself pr
 
 [slides-lab]: https://docs.google.com/presentation/d/1wJk_1dxEsj2nrpLMvyhaYaZCaLo_r17L_-Cb7rmdduA/edit?usp=sharing
 
-[bugs]: readme.md#bugs
+[bugs]: https://github.com/cmda-bt/be-course-18-19#communication
 
 [quote-author]: https://twitter.com/shatterfront/status/816065700577972224
 

--- a/week-6.md
+++ b/week-6.md
@@ -71,7 +71,7 @@ Presenting your work is a skill all by itself, make sure you prepare yourself pr
 
 [slides-lab]: https://docs.google.com/presentation/d/1QKkcyzQzQFmcaDXrZkER4_B458EtxV-DEYDE3V1gAY4/edit?usp=sharing
 
-[bugs]: readme.md#bugs
+[bugs]: https://github.com/cmda-bt/be-course-18-19#communication
 
 [quote-author]: http://mathforum.org/ken/perl_modules.html#document
 


### PR DESCRIPTION
Relative links to the root readme apparently are broken, I can't seem to replicate the problem on my own repo. A hardcoded link like this should work